### PR TITLE
Add required compiler flag to gearmand-0.34-r1.ebuild

### DIFF
--- a/sys-cluster/gearmand/gearmand-0.34-r1.ebuild
+++ b/sys-cluster/gearmand/gearmand-0.34-r1.ebuild
@@ -51,6 +51,9 @@ src_configure() {
 		# preprocessor then.
 		append-cppflags -DDEBUG
 	fi
+	
+	# Explicitly enable c++11 mode
+	append-cppflags -std=c++11
 
 	autotools-utils_src_configure
 }


### PR DESCRIPTION
Germand not compiling in compilers that not use c++11 by default (eg. gcc < 5.0)
Enabling this mode explicitly in ebuild.
